### PR TITLE
f-strings to replace str.format()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
 language: python
 python:
- - "3.6"
+  - "3.6"
+  # - "pypy3"  # might be faster that CPython for big compiles
 install:
- - pip install codecov flake8
+  - pip install codecov flake8
 addons:
   apt:
     packages:
     - binutils
     - gcc
 before_script:
-  # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 . --count --show-source --statistics
+  - flake8 . --exit-zero --max-complexity=15
 script: coverage run -m unittest discover
 after_success: codecov

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 ---
 
-ShivyC is a hobby C compiler written in Python that supports a subset of the C11 standard and generates reasonably efficient binaries, including some optimizations. ShivyC also generates helpful compile-time error messages.
+ShivyC is a hobby C compiler written in Python 3 that supports a subset of the C11 standard and generates reasonably efficient binaries, including some optimizations. ShivyC also generates helpful compile-time error messages.
 
 This [implementation of a trie](tests/general_tests/trie/trie.c) is an example of what ShivyC can compile today. For a more comprehensive list of features, see the [feature test directory](tests/feature_tests).
 
 ## Quickstart
 
 ### x86-64 Linux
-ShivyC requires only Python 3 to compile C code. Assembling and linking are done using the GNU binutils and glibc, which you almost certainly already have installed.
+ShivyC requires only Python 3.6 or later to compile C code. Assembling and linking are done using the GNU binutils and glibc, which you almost certainly already have installed.
 
 To install ShivyC:
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,17 @@
 """ShivyC installation script."""
 
-import sys
-
-import shivyc
-from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-VERSION = str(shivyc.__version__)
-DOWNLOAD_URL = ("https://github.com/ShivamSarodia/ShivyC/archive/{}.tar.gz"
-                .format(VERSION))
+from setuptools import find_packages, setup
 
-if sys.version_info[0] < 3:
-    sys.exit("ShivyC only supports Python 3.")
+import shivyc
+
+f"ShivyC only supports Python 3.6 or later"  # f-str is Syntax Err before Py3.6
+
+VERSION = str(shivyc.__version__)
+DOWNLOAD_URL = ('https://github.com/ShivamSarodia/ShivyC/archive/'
+                f'{VERSION}.tar.gz')
 
 here = path.abspath(path.dirname(__file__))
 

--- a/shivyc/errors.py
+++ b/shivyc/errors.py
@@ -35,6 +35,7 @@ class ErrorCollector:
         """Clear all warnings and errors. Intended only for testing use."""
         self.issues = []
 
+
 error_collector = ErrorCollector()
 
 
@@ -70,7 +71,7 @@ class Range:
     def __init__(self, start, end=None):
         """Initialize Range objects."""
         self.start = start
-        self.end = end if end else start
+        self.end = end or start
 
     def __add__(self, other):
         """Add Range objects by concatenating their ranges."""
@@ -134,25 +135,12 @@ class CompilerError(Exception):
                                     self.range.start.col + 1)
 
             indicator += reset_color
-
-            insert = [bold_color,
-                      self.range.start.file,
-                      self.range.start.line,
-                      self.range.start.col,
-                      color_code,
-                      issue_type,
-                      reset_color,
-                      self.descrip,
-                      self.range.start.full_line,
-                      indicator]
-
-            return "{}{}:{}:{}: {}{}:{} {}\n  {}\n  {}".format(*insert)
-
+            return (f"{bold_color}{self.range.start.file}:"
+                    f"{self.range.start.line}:{self.range.start.col}: "
+                    f"{color_code}{issue_type}:{reset_color} {self.descrip}\n"
+                    f"  {self.range.start.full_line}\n"
+                    f"  {indicator}")
         # A position range is not provided and this is output to terminal.
         else:
-            insert = [bold_color,
-                      color_code,
-                      issue_type,
-                      reset_color,
-                      self.descrip]
-            return "{}shivyc: {}{}:{} {}".format(*insert)
+            return (f"{bold_color}shivyc: {color_code}{issue_type}:"
+                    f"{reset_color} {self.descrip}")

--- a/shivyc/il_gen.py
+++ b/shivyc/il_gen.py
@@ -132,7 +132,7 @@ class ILValue:
         self.null_ptr_const = null_ptr_const
 
     def __str__(self):  # pragma: no cover
-        return str(id(self) % 1000).zfill(3)
+        return f'{id(self) % 1000:03}'
 
     def __repr__(self):  # pragma: no cover
         return str(self)
@@ -174,7 +174,8 @@ class SymbolTable:
 
         """
         for table, _ in self.tables[::-1]:
-            if name in table: return table[name]
+            if name in table:
+                return table[name]
 
     def lookup_tok(self, identifier):
         """Look up the given identifier.
@@ -189,9 +190,8 @@ class SymbolTable:
         if ret:
             return ret
         else:
-            descrip = "use of undeclared identifier '{}'"
-            raise CompilerError(
-                descrip.format(identifier.content), identifier.r)
+            descrip = f"use of undeclared identifier '{identifier.content}'"
+            raise CompilerError(descrip, identifier.r)
 
     def add(self, identifier, ctype):
         """Add an identifier with the given name and type to the symbol table.
@@ -206,8 +206,7 @@ class SymbolTable:
             self.tables[-1].vars[name] = il_value
             return il_value
         else:
-            descrip = "redefinition of '{}'"
-            raise CompilerError(descrip.format(name), identifier.r)
+            raise CompilerError(f"redefinition of '{name}'", identifier.r)
 
     def lookup_struct(self, tag):
         """Look up struct by tag name and return its ctype object.

--- a/shivyc/lexer.py
+++ b/shivyc/lexer.py
@@ -393,7 +393,7 @@ def add_chunk(chunk, tokens):
                 token_kinds.identifier, identifier_name, r=range))
             return
 
-        descrip = "unrecognized token at '{}'".format(chunk_to_str(chunk))
+        descrip = f"unrecognized token at '{chunk_to_str(chunk)}'"
         raise CompilerError(descrip, range)
 
 

--- a/shivyc/main.py
+++ b/shivyc/main.py
@@ -47,8 +47,8 @@ def process_file(file, args):
     elif file[-2:] == ".o":
         return file
     else:
-        err = "unknown file type: '{}'"
-        error_collector.add(CompilerError(err.format(file)))
+        err = f"unknown file type: '{file}'"
+        error_collector.add(CompilerError(err))
         return None
 
 
@@ -129,8 +129,8 @@ def read_file(file):
         with open(file) as c_file:
             return c_file.read()
     except IOError as e:
-        descrip = "could not read file: '{}'"
-        error_collector.add(CompilerError(descrip.format(file)))
+        descrip = f"could not read file: '{file}'"
+        error_collector.add(CompilerError(descrip))
 
 
 def write_asm(asm_source, asm_filename):
@@ -144,8 +144,8 @@ def write_asm(asm_source, asm_filename):
         with open(asm_filename, "w") as s_file:
             s_file.write(asm_source)
     except IOError:
-        descrip = "could not write output file '{}'"
-        error_collector.add(CompilerError(descrip.format(asm_filename)))
+        descrip = f"could not write output file '{asm_filename}'"
+        error_collector.add(CompilerError(descrip))
 
 
 def assemble(asm_name, obj_name):
@@ -208,7 +208,7 @@ def find_library_or_err(file):
     """
     path = find_library(file)
     if not path:
-        err = "could not find {}".format(file)
+        err = f"could not find {file}"
         error_collector.add(CompilerError(err))
         return None
     else:

--- a/shivyc/parser/statement.py
+++ b/shivyc/parser/statement.py
@@ -17,40 +17,13 @@ def parse_statement(index):
     parse failures. On the last try, raise the exception on to the caller.
 
     """
-    try:
-        return parse_compound_statement(index)
-    except ParserError as e:
-        log_error(e)
-
-    try:
-        return parse_return(index)
-    except ParserError as e:
-        log_error(e)
-
-    try:
-        return parse_break(index)
-    except ParserError as e:
-        log_error(e)
-
-    try:
-        return parse_continue(index)
-    except ParserError as e:
-        log_error(e)
-
-    try:
-        return parse_if_statement(index)
-    except ParserError as e:
-        log_error(e)
-
-    try:
-        return parse_while_statement(index)
-    except ParserError as e:
-        log_error(e)
-
-    try:
-        return parse_for_statement(index)
-    except ParserError as e:
-        log_error(e)
+    for func in (parse_compound_statement, parse_return, parse_break,
+                 parse_continue, parse_if_statement, parse_while_statement,
+                 parse_for_statement):
+        try:
+            return func(index)
+        except ParserError as e:
+            log_error(e)
 
     return parse_expr_statement(index)
 
@@ -187,7 +160,7 @@ def _get_for_clauses(index):
 
     if token_is(index, token_kinds.close_paren):
         third = None
-        index = index + 1
+        index += 1
     else:
         third, index = parse_expression(index)
         index = match_token(index, token_kinds.close_paren, ParserError.AFTER)

--- a/shivyc/parser/utils.py
+++ b/shivyc/parser/utils.py
@@ -47,7 +47,7 @@ class ParserError(CompilerError):
         self.amount_parsed = index
 
         if len(tokens) == 0:
-            super().__init__("{} at beginning of source".format(message))
+            super().__init__(f"{message} at beginning of source")
             return
 
         # If the index is too big, we're always using the AFTER form
@@ -61,10 +61,10 @@ class ParserError(CompilerError):
                 message_type = self.GOT
 
         if message_type == self.AT:
-            super().__init__("{} at '{}'".format(message, tokens[index]),
+            super().__init__(f"{message} at '{tokens[index]}'",
                              tokens[index].r)
         elif message_type == self.GOT:
-            super().__init__("{}, got '{}'".format(message, tokens[index]),
+            super().__init__(f"{message}, got '{tokens[index]}'",
                              tokens[index].r)
         elif message_type == self.AFTER:
             if tokens[index - 1].r:
@@ -73,7 +73,7 @@ class ParserError(CompilerError):
                 new_range = None
 
             super().__init__(
-                "{} after '{}'".format(message, tokens[index - 1]), new_range)
+                f"{message} after '{tokens[index - 1]}'", new_range)
 
 
 def raise_error(err, index, error_type):
@@ -117,7 +117,7 @@ def match_token(index, kind, message_type, message=None):
     """
     global tokens
     if not message:
-        message = "expected '{}'".format(kind.text_repr)
+        message = f"expected '{kind.text_repr}'"
 
     if token_is(index, kind):
         return index + 1

--- a/shivyc/spots.py
+++ b/shivyc/spots.py
@@ -149,21 +149,19 @@ class MemSpot(Spot):
         if total_offset == 0:
             simple = base_str
         elif total_offset > 0:
-            simple = "{}+{}".format(base_str, total_offset)
+            simple = f"{base_str}+{total_offset}"
         else:  # total_offset < 0
-            simple = "{}-{}".format(base_str, -total_offset)
+            simple = f"{base_str}-{-total_offset}"
 
         if self.count and self.chunk > 0:
-            final = "{}+{}*{}".format(
-                simple, self.chunk, self.count.asm_str(8))
+            final = f"{simple}+{self.chunk}*{self.count.asm_str(8)}"
         elif self.count and self.chunk < 0:
-            final = "{}-{}*{}".format(
-                simple, -self.chunk, self.count.asm_str(8))
+            final = f"{simple}-{-self.chunk}*{self.count.asm_str(8)}"
         else:
             final = simple
 
         size_desc = self.size_map.get(size, "")
-        return "{}[{}]".format(size_desc, final)
+        return f"{size_desc}[{final}]"
 
     def rbp_offset(self):  # noqa D102
         if self.base == RBP:

--- a/shivyc/tree/expr_nodes.py
+++ b/shivyc/tree/expr_nodes.py
@@ -566,7 +566,7 @@ class _BoolAndOr(_RExprNode):
         # Label which skips the line which sets out to 0 or 1.
         end = il_code.get_label()
 
-        err = "'{}' operator requires scalar operands".format(str(self.op))
+        err = f"'{str(self.op)}' operator requires scalar operands"
         left = self.left.make_il(il_code, symbol_table, c)
         if not left.ctype.is_scalar():
             raise CompilerError(err, self.left.r)
@@ -643,8 +643,8 @@ class _CompoundPlusMinus(_RExprNode):
         right = self.right.make_il(il_code, symbol_table, c)
         lvalue = self.left.lvalue(il_code, symbol_table, c)
         if not lvalue or not lvalue.modable():
-            err = "expression on left of '{}' is not assignable"
-            raise CompilerError(err.format(str(self.op)), self.left.r)
+            err = f"expression on left of '{str(self.op)}' is not assignable"
+            raise CompilerError(err, self.left.r)
 
         if (lvalue.ctype().is_pointer()
             and right.ctype.is_integral()
@@ -678,7 +678,7 @@ class _CompoundPlusMinus(_RExprNode):
             return out
 
         else:
-            err = "invalid types for '{}' operator".format(str(self.op))
+            err = f"invalid types for '{str(self.op)}' operator"
             raise CompilerError(err, self.op.r)
 
 
@@ -734,8 +734,8 @@ class _IncrDecr(_RExprNode):
         lval = self.expr.lvalue(il_code, symbol_table, c)
 
         if not lval or not lval.modable():
-            err = "operand of {} operator not a modifiable lvalue"
-            raise CompilerError(err.format(self.descrip), self.expr.r)
+            err = f"operand of {self.descrip} operator not a modifiable lvalue"
+            raise CompilerError(err, self.expr.r)
 
         val = self.expr.make_il(il_code, symbol_table, c)
         one = ILValue(val.ctype)
@@ -747,8 +747,8 @@ class _IncrDecr(_RExprNode):
             err = "invalid arithmetic on pointer to incomplete type"
             raise CompilerError(err, self.op.r)
         else:
-            err = "invalid type for {} operator"
-            raise CompilerError(err.format(self.descrip), self.expr.r)
+            err = f"invalid type for {self.descrip} operator"
+            raise CompilerError(err, self.expr.r)
 
         new_val = ILValue(val.ctype)
 
@@ -988,8 +988,7 @@ class _ObjLookup(_LExprNode):
 
         offset, ctype = struct_ctype.get_offset(self.member.content)
         if offset is None:
-            err = "structure or union has no member '{}'".format(
-                self.member.content)
+            err = f"structure or union has no member '{self.member.content}'"
             raise CompilerError(err, self.r)
 
         if struct_ctype.is_const():
@@ -1106,9 +1105,8 @@ class FuncCall(_RExprNode):
         else:
             arg_types = func_ctype.args
         if len(arg_types) != len(self.args):
-            err = ("incorrect number of arguments for function call" +
-                   " (expected {}, have {})").format(len(arg_types),
-                                                     len(self.args))
+            err = ("incorrect number of arguments for function call"
+                   f" (expected {len(arg_types)}, have {len(self.args)})")
 
             if self.args:
                 raise CompilerError(err, self.args[-1].r)

--- a/shivyc/tree/nodes.py
+++ b/shivyc/tree/nodes.py
@@ -127,7 +127,7 @@ class _BreakContinue(Node):
             il_code.add(control_cmds.Jump(label))
         else:
             with report_err():
-                err = "{} statement not in loop".format(self.descrip)
+                err = f"{self.descrip} statement not in loop"
                 raise CompilerError(err, self.r)
 
 
@@ -568,7 +568,7 @@ class Declaration(Node):
                 ctype = symbol_table.add_struct(tag, StructCType(tag))
 
             if has_members and ctype.is_complete():
-                err = "redefinition of 'struct {}'".format(tag)
+                err = f"redefinition of 'struct {tag}'"
                 raise CompilerError(err, node.r)
 
         else:
@@ -609,7 +609,7 @@ class Declaration(Node):
                     attr = decl_info.identifier.content
 
                     if attr in member_set:
-                        err = "duplicate member '{}'".format(attr)
+                        err = f"duplicate member '{attr}'"
                         raise CompilerError(err, decl_info.identifier.r)
 
                     members.append((attr, decl_info.ctype))

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -174,22 +174,22 @@ class IntegrationTests(TestUtils):
         self.assertEqual(error_collector.issues, [])
 
         # Compile with gcc
-        gcc_compile = "gcc -std=c11 {0}/{1} -o gcc_out".format(dir, cfile)
+        gcc_compile = f"gcc -std=c11 {dir}/{cfile} -o gcc_out"
         subprocess.run(gcc_compile, shell=True, check=True)
 
         # Run ShivyC executable on sample input
         if stdin:
-            shivyc_run = "./out < {0}/input.c > {0}/shivyc_output".format(dir)
-            gcc_run = "./gcc_out < {0}/input.c > {0}/gcc_output".format(dir)
+            shivyc_run = f"./out < {dir}/input.c > {dir}/shivyc_output"
+            gcc_run = f"./gcc_out < {dir}/input.c > {dir}/gcc_output"
         else:
-            shivyc_run = "./out > {0}/shivyc_output".format(dir)
-            gcc_run = "./gcc_out > {0}/gcc_output".format(dir)
+            shivyc_run = f"./out > {dir}/shivyc_output"
+            gcc_run = f"./gcc_out > {dir}/gcc_output"
 
         subprocess.run(shivyc_run, shell=True, check=True)
         subprocess.run(gcc_run, shell=True, check=True)
 
         # Diff the two output files
-        diff = "diff {0}/gcc_output {0}/shivyc_output".format(dir)
+        diff = f"diff {dir}/gcc_output {dir}/shivyc_output"
         subprocess.run(diff, shell=True, check=True)
 
     def test_count(self):


### PR DESCRIPTION
Would it be acceptable to move to Python 3.6 and better to get f-string support?

They speed up string concatenation via pre-compilation and a new special bytecode.  Applying f-strings to code generation should speed up that process as well.