### PR TITLE
Fix various function declaration bugs

### DIFF
--- a/shivyc/ctypes.py
+++ b/shivyc/ctypes.py
@@ -231,30 +231,35 @@ class FunctionCType(CType):
     args (List(CType)) - List of the argument ctypes, from left to right, or
     None if unspecified.
     ret (CType) - Return value of the function.
-
+    no_info (bool) - True if the function does not have any parameter info.
+    This occurs when the function is declared as `int f();` with nothing in
+    between the parentheses.
     """
 
-    def __init__(self, args, ret):
+    def __init__(self, args, ret, no_info=False):
         """Initialize type."""
         self.args = args
         self.ret = ret
+        self.no_info = no_info
         super().__init__(1)
 
     def weak_compat(self, other):
         """Return True iff other is a compatible type to self."""
 
-        # TODO: This is not implemented correctly. Function pointer
-        # compatibility rules are confusing.
-
         if not other.is_function():
-            return False
-        elif len(self.args) != len(other.args):
-            return False
-        elif any(not a1.compatible(a2) for a1, a2 in
-                 zip(self.args, other.args)):
             return False
         elif not self.ret.compatible(other.ret):
             return False
+        elif not self.no_info and not other.no_info:
+            if len(self.args) != len(other.args):
+                return False
+            elif any(not a1.compatible(a2) for a1, a2 in
+                     zip(self.args, other.args)):
+                return False
+
+        # TODO: There are special rules for compatibility between a function
+        # with parameter list and a function without parameter list. See
+        # 6.7.6.3.15.
 
         return True
 

--- a/shivyc/ctypes.py
+++ b/shivyc/ctypes.py
@@ -93,6 +93,12 @@ class CType:
         const_self.const = True
         return const_self
 
+    def make_unqual(self):
+        """Return an unqualified version of this type."""
+        unqual_self = copy.copy(self)
+        unqual_self.const = False
+        return unqual_self
+
 
 class IntegerCType(CType):
     """Represents an integer C type, like 'unsigned long' or 'bool'.

--- a/shivyc/tree/expr_nodes.py
+++ b/shivyc/tree/expr_nodes.py
@@ -1062,7 +1062,7 @@ class FuncCall(_RExprNode):
             descrip = "called object is not a function pointer"
             raise CompilerError(descrip, self.func.r)
 
-        if not func.ctype.arg.args:
+        if func.ctype.arg.no_info:
             final_args = self._get_args_without_prototype(
                 il_code, symbol_table, c)
         else:
@@ -1099,11 +1099,8 @@ class FuncCall(_RExprNode):
         expected types.
         """
         # if only parameter is of type void, expect no arguments
-        if (len(func_ctype.args) == 1 and
-             func_ctype.args[0].is_void()):
-            arg_types = []
-        else:
-            arg_types = func_ctype.args
+        arg_types = func_ctype.args
+
         if len(arg_types) != len(self.args):
             err = ("incorrect number of arguments for function call"
                    f" (expected {len(arg_types)}, have {len(self.args)})")

--- a/shivyc/tree/expr_nodes.py
+++ b/shivyc/tree/expr_nodes.py
@@ -1061,6 +1061,13 @@ class FuncCall(_RExprNode):
         if not func.ctype.is_pointer() or not func.ctype.arg.is_function():
             descrip = "called object is not a function pointer"
             raise CompilerError(descrip, self.func.r)
+        elif (not func.ctype.arg.ret.is_complete()
+              and not func.ctype.arg.ret.is_void()):
+            # TODO: C11 spec says a function cannot return an array type,
+            # but I can't determine how a function would ever be able to return
+            # an array type.
+            descrip = "function returns non-void incomplete type"
+            raise CompilerError(descrip, self.func.r)
 
         if func.ctype.arg.no_info:
             final_args = self._get_args_without_prototype(
@@ -1098,7 +1105,6 @@ class FuncCall(_RExprNode):
         has a prototype. This function converts all passed arguments to
         expected types.
         """
-        # if only parameter is of type void, expect no arguments
         arg_types = func_ctype.args
 
         if len(arg_types) != len(self.args):
@@ -1114,5 +1120,6 @@ class FuncCall(_RExprNode):
         for arg_given, arg_type in zip(self.args, arg_types):
             arg = arg_given.make_il(il_code, symbol_table, c)
             check_cast(arg, arg_type, arg_given.r)
-            final_args.append(set_type(arg, arg_type, il_code))
+            final_args.append(
+                set_type(arg, arg_type.make_unqual(), il_code))
         return final_args

--- a/shivyc/tree/nodes.py
+++ b/shivyc/tree/nodes.py
@@ -459,10 +459,14 @@ class Declaration(Node):
 
             # Function declarators cannot have a function or array return type.
             # TODO: Relevant only when typedef is implemented.
-            # if prev_ctype.is_function() or prev_ctype.is_array():
-            #    pass
 
-            new_ctype = FunctionCType(args, prev_ctype)
+            if has_void:
+                new_ctype = FunctionCType([], prev_ctype, False)
+            elif not args:
+                new_ctype = FunctionCType([], prev_ctype, True)
+            else:
+                new_ctype = FunctionCType(args, prev_ctype)
+
         elif isinstance(decl, decl_nodes.Identifier):
             return prev_ctype, decl.identifier
 

--- a/tests/feature_tests/declaration.c
+++ b/tests/feature_tests/declaration.c
@@ -1,7 +1,7 @@
 // Verify we can declare variables before and after main
 extern int a;
 
-int f(int[5], int());
+int f0(int[5], int());
 
 int f1(void);
 
@@ -21,6 +21,10 @@ int main() {
   int *f(int, unsigned int* b, long *[5], long (*)[5]);
   int g();
   int h(void);
+
+  int (*f3)(int, int, int), f4(int, int, int);
+  // verify f1 and f2 are compatible
+  f3 = f4;
 }
 
 extern int z;

--- a/tests/feature_tests/declaration.c
+++ b/tests/feature_tests/declaration.c
@@ -1,6 +1,12 @@
 // Verify we can declare variables before and after main
 extern int a;
 
+int f(int[5], int());
+
+int f1(void);
+
+int f2();
+
 int main() {
   int;
 

--- a/tests/feature_tests/error_declaration.c
+++ b/tests/feature_tests/error_declaration.c
@@ -1,3 +1,9 @@
+// error: storage class specified for function parameter
+int func(auto int a);
+
+// error: 'void' must be the only parameter
+int func1(void, void);
+
 int main() {
   // error: variable of void type declared
   void a;

--- a/tests/feature_tests/error_declaration.c
+++ b/tests/feature_tests/error_declaration.c
@@ -28,4 +28,16 @@ int main() {
   }
   // error: use of undeclared identifier 'c'
   c;
+
+  int (*f1)(int), f2(int, int);
+  // error: conversion from incompatible pointer type
+  f1 = f2;
+
+  void (*f3)(int);
+  // error: conversion from incompatible pointer type
+  f1 = f3;
+
+  void (*f4)(long);
+  // error: conversion from incompatible pointer type
+  f3 = f4;
 }

--- a/tests/feature_tests/error_function_call.c
+++ b/tests/feature_tests/error_function_call.c
@@ -4,6 +4,8 @@ int isalpha(int);
 // verify that a void parameter works.
 int isdigit(void);
 
+struct S incomplete_return();
+
 int main() {
   int a;
 
@@ -23,6 +25,9 @@ int main() {
 
   // error: incorrect number of arguments for function call (expected 0, have 2)
   isdigit(1, 2);
+
+  // error: function returns non-void incomplete type
+  incomplete_return();
 
   return 0;
 }

--- a/tests/feature_tests/error_pointer.c
+++ b/tests/feature_tests/error_pointer.c
@@ -25,5 +25,9 @@
   // error: conversion from incompatible pointer type
   f = g;
 
+  int (*h)();
+  // error: conversion from incompatible pointer type
+  h = f;
+
   return 0;
  }

--- a/tests/feature_tests/function_call.c
+++ b/tests/feature_tests/function_call.c
@@ -5,6 +5,8 @@ int strcmp(char*, char*);
 char* strcpy(char*, char*);
 char* strncpy(char*, char*, long);
 
+int signal(int, int a(int));
+
 int main() {
   // Try out a few function calls from standard library.
 
@@ -42,6 +44,9 @@ int main() {
 
   int (*f2)(int) = isalpha;
   if(f2(5)) return 12;
+
+  // test passing a function to a function
+  signal(0, isalpha);
 
   return 0;
 }

--- a/tests/feature_tests/function_call.c
+++ b/tests/feature_tests/function_call.c
@@ -5,7 +5,7 @@ int strcmp(char*, char*);
 char* strcpy(char*, char*);
 char* strncpy(char*, char*, long);
 
-int signal(int, int a(int));
+int signal(int, int(int));
 
 int main() {
   // Try out a few function calls from standard library.


### PR DESCRIPTION
Makes function declaration rules in ShivyC adhere closer to the C11 spec.  Currently, the following are still unimplemented:

- 6.7.6.3.4 - incomplete types are not allowed in function definitions
- 6.7.6.3.7 - type specifiers inside the square [ ] of function parameters
- 6.7.6.3.9 - varargs
- struct as function argument or return value

These tasks are moved to #62.