### PR TITLE
Refactor codegen for unsigned multiplication

### DIFF
--- a/shivyc/asm_cmds.py
+++ b/shivyc/asm_cmds.py
@@ -150,9 +150,6 @@ class Sub(_ASMCommand): name = "sub"  # noqa: D101
 class Neg(_ASMCommand): name = "neg"  # noqa: D101
 
 
-class Mul(_ASMCommand): name = "mul"  # noqa: D101
-
-
 class Div(_ASMCommand): name = "div"  # noqa: D101
 
 

--- a/shivyc/il_cmds/math.py
+++ b/shivyc/il_cmds/math.py
@@ -6,82 +6,16 @@ from shivyc.il_cmds.base import ILCommand
 
 
 class _AddMult(ILCommand):
-    """Base class for ADD and MULT.
+    """Base class for ADD, MULT, and SUB."""
 
-    Contains function that implements the shared code between these.
-    """
+    # Indicates whether this instruction is commutative. If not,
+    # a "neg" instruction is inserted when the order is flipped. Override
+    # this value in subclasses.
+    comm = False
 
-    def _shared_asm(self, Inst, comm, out, arg1, arg2, spotmap, get_reg,
-                    asm_code):
-        """Make the shared ASM for ADD, MULT, and SUB.
-
-        Inst - the instruction for this
-        comm (Bool) - whether the instruction is commutative. if not,
-        a "neg" instruction is inserted when the order is flipped.
-        """
-        ctype = arg1.ctype
-        size = ctype.size
-
-        arg1_spot = spotmap[arg1]
-        arg2_spot = spotmap[arg2]
-
-        # Get temp register for computation.
-        temp = get_reg([spotmap[out],
-                        arg1_spot,
-                        arg2_spot])
-
-        if temp == arg1_spot:
-            if not self._is_imm64(arg2_spot):
-                asm_code.add(Inst(temp, arg2_spot, size))
-            else:
-                temp2 = get_reg([], [temp])
-                asm_code.add(asm_cmds.Mov(temp2, arg2_spot, size))
-                asm_code.add(Inst(temp, temp2, size))
-        elif temp == arg2_spot:
-            if not self._is_imm64(arg1_spot):
-                asm_code.add(Inst(temp, arg1_spot, size))
-            else:
-                temp2 = get_reg([], [temp])
-                asm_code.add(asm_cmds.Mov(temp2, arg1_spot, size))
-                asm_code.add(Inst(temp, temp2, size))
-
-            if not comm:
-                asm_code.add(asm_cmds.Neg(temp, None, size))
-
-        else:
-            if (not self._is_imm64(arg1_spot) and
-                 not self._is_imm64(arg2_spot)):
-                asm_code.add(asm_cmds.Mov(temp, arg1_spot, size))
-                asm_code.add(Inst(temp, arg2_spot, size))
-            elif (self._is_imm64(arg1_spot) and
-                  not self._is_imm64(arg2_spot)):
-                asm_code.add(asm_cmds.Mov(temp, arg1_spot, size))
-                asm_code.add(Inst(temp, arg2_spot, size))
-            elif (not self._is_imm64(arg1_spot) and
-                  self._is_imm64(arg2_spot)):
-                asm_code.add(asm_cmds.Mov(temp, arg2_spot, size))
-                asm_code.add(Inst(temp, arg1_spot, size))
-                if not comm:
-                    asm_code.add(asm_cmds.Neg(temp, None, size))
-
-            else:  # both are imm64
-                temp2 = get_reg([], [temp])
-
-                asm_code.add(asm_cmds.Mov(temp, arg1_spot, size))
-                asm_code.add(asm_cmds.Mov(temp2, arg2_spot, size))
-                asm_code.add(Inst(temp, temp2, size))
-
-        if temp != spotmap[out]:
-            asm_code.add(asm_cmds.Mov(spotmap[out], temp, size))
-
-
-class Add(_AddMult):
-    """ADD - adds arg1 and arg2, then saves to output.
-
-    IL values output, arg1, arg2 must all have the same type. No type
-    conversion or promotion is done here.
-
-    """
+    # The ASM instruction to generate for this command. Override this value
+    # in subclasses.
+    Inst = None
 
     def __init__(self, output, arg1, arg2): # noqa D102
         self.output = output
@@ -98,109 +32,90 @@ class Add(_AddMult):
         return {self.output: [self.arg1, self.arg2]}
 
     def make_asm(self, spotmap, home_spots, get_reg, asm_code): # noqa D102
-        self._shared_asm(asm_cmds.Add, True, self.output, self.arg1, self.arg2,
-                         spotmap, get_reg, asm_code)
+        """Make the ASM for ADD, MULT, and SUB."""
+        ctype = self.arg1.ctype
+        size = ctype.size
+
+        arg1_spot = spotmap[self.arg1]
+        arg2_spot = spotmap[self.arg2]
+
+        # Get temp register for computation.
+        temp = get_reg([spotmap[self.output],
+                        arg1_spot,
+                        arg2_spot])
+
+        if temp == arg1_spot:
+            if not self._is_imm64(arg2_spot):
+                asm_code.add(self.Inst(temp, arg2_spot, size))
+            else:
+                temp2 = get_reg([], [temp])
+                asm_code.add(asm_cmds.Mov(temp2, arg2_spot, size))
+                asm_code.add(self.Inst(temp, temp2, size))
+        elif temp == arg2_spot:
+            if not self._is_imm64(arg1_spot):
+                asm_code.add(self.Inst(temp, arg1_spot, size))
+            else:
+                temp2 = get_reg([], [temp])
+                asm_code.add(asm_cmds.Mov(temp2, arg1_spot, size))
+                asm_code.add(self.Inst(temp, temp2, size))
+
+            if not self.comm:
+                asm_code.add(asm_cmds.Neg(temp, None, size))
+
+        else:
+            if (not self._is_imm64(arg1_spot) and
+                 not self._is_imm64(arg2_spot)):
+                asm_code.add(asm_cmds.Mov(temp, arg1_spot, size))
+                asm_code.add(self.Inst(temp, arg2_spot, size))
+            elif (self._is_imm64(arg1_spot) and
+                  not self._is_imm64(arg2_spot)):
+                asm_code.add(asm_cmds.Mov(temp, arg1_spot, size))
+                asm_code.add(self.Inst(temp, arg2_spot, size))
+            elif (not self._is_imm64(arg1_spot) and
+                  self._is_imm64(arg2_spot)):
+                asm_code.add(asm_cmds.Mov(temp, arg2_spot, size))
+                asm_code.add(self.Inst(temp, arg1_spot, size))
+                if not self.comm:
+                    asm_code.add(asm_cmds.Neg(temp, None, size))
+
+            else:  # both are imm64
+                temp2 = get_reg([], [temp])
+
+                asm_code.add(asm_cmds.Mov(temp, arg1_spot, size))
+                asm_code.add(asm_cmds.Mov(temp2, arg2_spot, size))
+                asm_code.add(self.Inst(temp, temp2, size))
+
+        if temp != spotmap[self.output]:
+            asm_code.add(asm_cmds.Mov(spotmap[self.output], temp, size))
 
 
-class Subtr(_AddMult):
-    """SUBTR - Subtracts arg1 and arg2, then saves to output.
-
-    ILValues output, arg1, and arg2 must all have types of the same size.
-    """
-
-    def __init__(self, output, arg1, arg2): # noqa D102
-        self.out = output
-        self.arg1 = arg1
-        self.arg2 = arg2
-
-    def inputs(self): # noqa D102
-        return [self.arg1, self.arg2]
-
-    def outputs(self): # noqa D102
-        return [self.out]
-
-    def rel_spot_pref(self): # noqa D102
-        return {self.out: [self.arg1]}
-
-    def make_asm(self, spotmap, home_spots, get_reg, asm_code): # noqa D102
-        self._shared_asm(asm_cmds.Sub, False, self.out, self.arg1, self.arg2,
-                         spotmap, get_reg, asm_code)
-
-
-class Mult(_AddMult):
-    """MULT - multiplies arg1 and arg2, then saves to output.
+class Add(_AddMult):
+    """Adds arg1 and arg2, then saves to output.
 
     IL values output, arg1, arg2 must all have the same type. No type
     conversion or promotion is done here.
-
     """
+    comm = True
+    Inst = asm_cmds.Add
 
-    def __init__(self, output, arg1, arg2):  # noqa D102
-        self.output = output
-        self.arg1 = arg1
-        self.arg2 = arg2
 
-    def inputs(self): # noqa D102
-        return [self.arg1, self.arg2]
+class Subtr(_AddMult):
+    """Subtracts arg1 and arg2, then saves to output.
 
-    def outputs(self): # noqa D102
-        return [self.output]
+    ILValues output, arg1, and arg2 must all have types of the same size.
+    """
+    comm = False
+    Inst = asm_cmds.Sub
 
-    def clobber(self):  # noqa D102
-        return [spots.RAX, spots.RDX] if not self.output.ctype.signed else []
 
-    def rel_spot_pref(self):  # noqa D102
-        if self.output.ctype.signed:
-            return {self.output: [self.arg1, self.arg2]}
-        else:
-            return {}
+class Mult(_AddMult):
+    """Multiplies arg1 and arg2, then saves to output.
 
-    def abs_spot_pref(self):  # noqa D102
-        if not self.output.ctype.signed:
-            return {self.output: [spots.RAX],
-                    self.arg1: [spots.RAX],
-                    self.arg2: [spots.RAX]}
-        else:
-            return {}
-
-    def make_asm(self, spotmap, home_spots, get_reg, asm_code): # noqa D102
-        ctype = self.arg1.ctype
-
-        # Unsigned multiplication
-        if not ctype.signed:
-            arg1_spot = spotmap[self.arg1]
-            arg2_spot = spotmap[self.arg2]
-            size = ctype.size
-
-            if arg1_spot == spots.RAX:
-                mul_spot = arg2_spot
-            elif arg2_spot == spots.RAX:
-                mul_spot = arg1_spot
-            else:
-                # If either is literal, move that one to RAX
-                if self._is_imm(arg2_spot):
-                    asm_code.add(asm_cmds.Mov(spots.RAX, arg2_spot, size))
-                    mul_spot = arg1_spot
-                else:
-                    asm_code.add(asm_cmds.Mov(spots.RAX, arg1_spot, size))
-                    mul_spot = arg2_spot
-
-            # Operand is an immediate, move it to a register
-            if self._is_imm(mul_spot):
-                r = get_reg([], [spots.RAX])
-                asm_code.add(asm_cmds.Mov(r, mul_spot, ctype.size))
-                mul_spot = r
-
-            asm_code.add(asm_cmds.Mul(mul_spot, None, ctype.size))
-
-            if spotmap[self.output] != spots.RAX:
-                asm_code.add(
-                    asm_cmds.Mov(spotmap[self.output], spots.RAX, ctype.size))
-
-        # Signed multiplication
-        else:
-            self._shared_asm(asm_cmds.Imul, True, self.output, self.arg1,
-                             self.arg2, spotmap, get_reg, asm_code)
+    IL values output, arg1, arg2 must all have the same type. No type
+    conversion or promotion is done here.
+    """
+    comm = True
+    Inst = asm_cmds.Imul
 
 
 class _DivMod(ILCommand):

--- a/tests/feature_tests/multiplication.c
+++ b/tests/feature_tests/multiplication.c
@@ -20,5 +20,13 @@ int main() {
   // Test order of operations
   if(3 + 2 * 3 != 9) return 4;
 
+  // Test unsigned int multiplication.
+  unsigned int j = 4294967295;
+  if(j * j != 1) return 5;
+  if((j - 1) * (j - 1) != 4) return 6;
+
+  long k = 2147483648;
+  if(k * j != 9223372034707292160) return 7;
+
   return 0;
 }


### PR DESCRIPTION
The imul x86 command can also do unsigned multiplication, so use that to simplify the code.