### PR TITLE
Fix bug in parsing function declarations

### DIFF
--- a/tests/feature_tests/declaration.c
+++ b/tests/feature_tests/declaration.c
@@ -15,6 +15,9 @@ int main() {
   int *f(int, unsigned int* b, long *[5], long (*)[5]);
   int g();
   int h(void);
+  int *i();
+  int *j(int);
+  int *k(int(int));
 }
 
 extern int z;


### PR DESCRIPTION
A declaration like: `int f(int(int));` would previously fail to compile with an internal compiler error. Fixed in this PR.