### PR TITLE
Implement storage class specifiers

### DIFF
--- a/shivyc/il_gen.py
+++ b/shivyc/il_gen.py
@@ -255,10 +255,14 @@ class SymbolTable:
             il_value = ILValue(ctype)
             self.tables[-1].vars[name] = self.Variable(
                 il_value, linkage, defined)
+            if linkage == self.INTERNAL:
+                self.internal[name] = il_value
+            elif linkage == self.EXTERNAL:
+                self.external[name] = il_value
 
         # Verify the type is compatible with the previous type
         if not il_value.ctype.compatible(ctype):
-            err = f"redeclaration of '{name}' with incompatible type",
+            err = f"redeclared '{name}' with incompatible type",
             raise CompilerError(err, identifier.r)
 
         return il_value

--- a/shivyc/il_gen.py
+++ b/shivyc/il_gen.py
@@ -175,15 +175,14 @@ class SymbolTable:
         `tables` is a list of namedtuples of dictionaries. Each dictionary
         in the namedtuple is the symbol table for a different namespace.
 
-        `linkage` has two dictionaries, each mapping an identifier (string)
-        to an ILValue. linkage[INTERNAL] is a dictionary storing all
-        variables with internal linkage, and linkage[EXTERNAL] is a
-        dictionary storing all variables with external linkage. Every
-        variable with internal or external linkage will be added to these
-        dictionaries, so that they can all be properly linked.
+        `internal` and `external` are dictionaries mapping an identifier (
+        string) to IL values. `internal` is used for all IL values with
+        internal linkage, and `external` is used for all IL values with
+        external linkage.
         """
         self.tables = []
-        self.linkages = {self.INTERNAL: {}, self.EXTERNAL: {}}
+        self.internal = {}
+        self.external = {}
         self.new_scope()
 
     def new_scope(self):
@@ -246,8 +245,11 @@ class SymbolTable:
                 raise CompilerError(err, identifier.r)
             il_value = var.il_value
 
-        elif name in self.linkages[linkage]:
-            il_value = self.linkages[linkage][name]
+        elif linkage == self.INTERNAL and name in self.internal:
+            il_value = self.internal[name]
+
+        elif linkage == self.EXTERNAL and name in self.external:
+            il_value = self.external[name]
 
         else:
             il_value = ILValue(ctype)

--- a/shivyc/tree/nodes.py
+++ b/shivyc/tree/nodes.py
@@ -376,6 +376,8 @@ class Declaration(Node):
         # determine whether this is a declaration or definition
         if decl_info.storage == decl_info.EXTERN and not decl_info.init:
             defined = False
+        elif decl_info.ctype.is_function():
+            defined = False
         else:
             defined = True
 

--- a/shivyc/tree/nodes.py
+++ b/shivyc/tree/nodes.py
@@ -367,36 +367,35 @@ class Declaration(Node):
             err = "variable of void type declared"
             raise CompilerError(err, decl_info.range)
 
-        var = symbol_table.add(decl_info.identifier, decl_info.ctype)
+        linkage = self.get_linkage(decl_info, symbol_table, c)
 
-        # Variables declared to be EXTERN
-        if decl_info.storage == DeclInfo.EXTERN:
-            il_code.register_extern_var(var, decl_info.identifier.content)
+        if not c.is_global and decl_info.init and linkage:
+            err = "variable with linkage has initializer"
+            raise CompilerError(err, decl_info.range)
 
-            # Extern variable should not have initializer
-            if decl_info.init:
-                err = "extern variable has initializer"
-                raise CompilerError(err, decl_info.range)
-
-        # Variables declared to be static
-        elif decl_info.storage == DeclInfo.STATIC:
-            # These should be in .data section, but not global
-            raise NotImplementedError("static variables unsupported")
-
-        # Global variables
-        elif c.is_global:
-            # Global functions are extern by default
-            if decl_info.ctype.is_function():
-                il_code.register_extern_var(var, decl_info.identifier.content)
-            else:
-                # These should be common if uninitialized, or data if
-                # initialized
-                raise NotImplementedError(
-                    "non-extern global variables unsupported")
-
-        # Local variables
+        # determine whether this is a declaration or definition
+        if decl_info.storage == decl_info.EXTERN and not decl_info.init:
+            defined = False
         else:
-            il_code.register_local_var(var)
+            defined = True
+
+        var = symbol_table.add(
+            decl_info.identifier,
+            decl_info.ctype,
+            defined,
+            linkage)
+
+        if not defined:
+            storage = None
+        elif linkage or decl_info.storage == decl_info.STATIC:
+            storage = il_code.STATIC
+        else:
+            storage = il_code.AUTOMATIC
+
+        name = decl_info.identifier.content
+        il_code.register_storage(var, storage, name)
+        if linkage == symbol_table.EXTERNAL:
+            il_code.register_extern_linkage(var, name)
 
         # Initialize variable if needed
         if decl_info.init:
@@ -409,16 +408,37 @@ class Declaration(Node):
                 err = "declared variable is not of assignable type"
                 raise CompilerError(err, decl_info.range)
 
+    def get_linkage(self, decl_info, symbol_table, c):
+        """Get linkage type for given decl_info object.
+
+        See 6.2.2 in the C11 spec for details.
+        """
+        if c.is_global and decl_info.storage == DeclInfo.STATIC:
+            linkage = symbol_table.INTERNAL
+        elif decl_info.storage == DeclInfo.EXTERN:
+            var = symbol_table.lookup_raw(decl_info.identifier.content)
+            if var and var.linkage:
+                linkage = var.linkage
+            else:
+                linkage = symbol_table.EXTERNAL
+        elif decl_info.ctype.is_function() and not decl_info.storage:
+            linkage = symbol_table.EXTERNAL
+        elif c.is_global and not decl_info.storage:
+            linkage = symbol_table.EXTERNAL
+        else:
+            linkage = None
+
+        return linkage
+
     def make_ctype(self, decl, prev_ctype, symbol_table):
         """Generate a ctype from the given declaration.
 
-        Return a `ctype, identifier token, storage class` triple.
+        Return a `ctype, identifier token` tuple.
 
         decl - Node of decl_nodes to parse. See decl_nodes.py for explanation
         about decl_nodess.
         prev_ctype - The ctype formed from all parts of the tree above the
         current one.
-        storage - The storage class of this declaration.
         """
         if isinstance(decl, decl_nodes.Pointer):
             new_ctype = PointerCType(prev_ctype, decl.const)

--- a/shivyc/tree/nodes.py
+++ b/shivyc/tree/nodes.py
@@ -394,6 +394,10 @@ class Declaration(Node):
         else:
             storage = il_code.AUTOMATIC
 
+        if storage == il_code.STATIC and decl_info.init:
+            raise NotImplementedError(
+                "initializer on static storage unsupported")
+
         name = decl_info.identifier.content
         il_code.register_storage(var, storage, name)
         if linkage == symbol_table.EXTERNAL:

--- a/tests/feature_tests/declaration.c
+++ b/tests/feature_tests/declaration.c
@@ -25,9 +25,12 @@ int main() {
   int *j(int);
   int *k(int(int));
 
+  // verify f3 and f4 are compatible
   int (*f3)(int, int, int), f4(int, int, int);
-  // verify f1 and f2 are compatible
-  f3 = f4;
+  // TODO: uncomment this when function definition is supported.
+  // Today, this line produces a linker error becuase f4 is not
+  // defined anywhere.
+  // f3 = f4;
 }
 
 extern int z;

--- a/tests/feature_tests/error_declaration.c
+++ b/tests/feature_tests/error_declaration.c
@@ -17,7 +17,7 @@ int main() {
   // error: unrecognized set of type specifiers
   unsigned signed int a;
 
-  // error: extern variable has initializer
+  // error: variable with linkage has initializer
   extern int a = 10;
 
   // error: too many storage classes in declaration specifiers

--- a/tests/feature_tests/error_declaration.c
+++ b/tests/feature_tests/error_declaration.c
@@ -4,6 +4,12 @@ int func(auto int a);
 // error: 'void' must be the only parameter
 int func1(void, void);
 
+extern int var;
+// error: redeclared 'var' with different linkage
+static int var;
+// error: redeclared 'var' with incompatible type
+extern long var;
+
 int main() {
   // error: variable of void type declared
   void a;
@@ -40,4 +46,8 @@ int main() {
   void (*f4)(long);
   // error: conversion from incompatible pointer type
   f3 = f4;
+
+  int redefined;
+  // error: redefinition of 'redefined'
+  int redefined;
 }

--- a/tests/feature_tests/error_storage.c
+++ b/tests/feature_tests/error_storage.c
@@ -1,5 +1,0 @@
-extern int hidden_var;
-
-int main() {
-  if(hidden_var == 0);
-}

--- a/tests/feature_tests/error_storage.c
+++ b/tests/feature_tests/error_storage.c
@@ -1,0 +1,5 @@
+extern int hidden_var;
+
+int main() {
+  if(hidden_var == 0);
+}

--- a/tests/feature_tests/storage.c
+++ b/tests/feature_tests/storage.c
@@ -1,15 +1,45 @@
-extern void* stdout;
-extern int does_not_exist;
+extern int extern_var;
+extern int extern_var;
 
-int func(void);
-extern int func2(void);
+extern void* stdout;
+
+int redef_func(int, int);
+int redef_func(int, int);
+
+static int intern_var;
+
+// should have no effect
+extern int intern_var;
+
+// has internal linkage
+int extern_var_2;
 
 int main() {
   auto char* p;
   p = stdout;
   if(*p + 124 != 0) return 1;
 
-  extern int inside_main_function;
+  if(extern_var != 0) return 2;
+  extern_var = 18;
+  if(extern_var != 18) return 3;
 
-  return 0;
+  {
+    int extern_var;
+    if(extern_var == 18) return 4;
+    {
+      extern int extern_var;
+      if(extern_var != 18) return 5;
+    }
+  }
+
+  {
+    // will have internal linkage
+    extern int intern_var;
+    intern_var = 7;
+    if(intern_var != 7) return 6;
+  }
+  {
+    // has internal linkage also
+    if(intern_var != 7) return 7;
+  }
 }

--- a/tests/feature_tests/storage_helper.c
+++ b/tests/feature_tests/storage_helper.c
@@ -1,0 +1,2 @@
+int extern_var;
+int extern_var_2;


### PR DESCRIPTION
Implement `static` and `extern`. Prerequisite to implementing function definitions.

Known issues
- Initializing variables with static storage is sometimes inefficient, sometimes incorrect
- The following code should work
```
static int a;
static int a;
```
but currently fails