### PR TITLE
Install vim while building docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,5 +2,6 @@ FROM ubuntu:artful
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip \
-    gcc
+    gcc \
+    vim
 CMD pip3 install -e . && /bin/bash


### PR DESCRIPTION
When I test the shivyc compiler on docker, I should able to edit some files. So I added vim to apt-get install list for it. It suppose that there are more vim users than fans of other editors.