### PR TITLE
Fix bug with error on nested postfix expressions

### DIFF
--- a/shivyc/parser/expression.py
+++ b/shivyc/parser/expression.py
@@ -162,7 +162,7 @@ def parse_postfix(index):
             match_token(index, token_kinds.identifier, ParserError.AFTER)
             member = p.tokens[index]
 
-            if token_is(index, token_kinds.dot):
+            if token_is(index - 1, token_kinds.dot):
                 cur = expr_nodes.ObjMember(cur, member)
             else:
                 cur = expr_nodes.ObjPtrMember(cur, member)

--- a/shivyc/parser/expression.py
+++ b/shivyc/parser/expression.py
@@ -147,13 +147,12 @@ def parse_postfix(index):
     cur, index = parse_primary(index)
 
     while True:
-        if len(p.tokens) > index:
-            tok = p.tokens[index]
+        old_range = cur.r
 
         if token_is(index, token_kinds.open_sq_brack):
             index += 1
             arg, index = parse_expression(index)
-            cur = expr_nodes.ArraySubsc(cur, arg, tok)
+            cur = expr_nodes.ArraySubsc(cur, arg)
             match_token(index, token_kinds.close_sq_brack, ParserError.GOT)
             index += 1
 
@@ -163,10 +162,10 @@ def parse_postfix(index):
             match_token(index, token_kinds.identifier, ParserError.AFTER)
             member = p.tokens[index]
 
-            if tok.kind == token_kinds.dot:
-                cur = expr_nodes.ObjMember(cur, member, tok)
+            if token_is(index, token_kinds.dot):
+                cur = expr_nodes.ObjMember(cur, member)
             else:
-                cur = expr_nodes.ObjPtrMember(cur, member, tok)
+                cur = expr_nodes.ObjPtrMember(cur, member)
 
             index += 1
 
@@ -175,7 +174,7 @@ def parse_postfix(index):
             index += 1
 
             if token_is(index, token_kinds.close_paren):
-                return expr_nodes.FuncCall(cur, args, tok), index + 1
+                return expr_nodes.FuncCall(cur, args), index + 1
 
             while True:
                 arg, index = parse_assignment(index)
@@ -189,7 +188,7 @@ def parse_postfix(index):
             index = match_token(
                 index, token_kinds.close_paren, ParserError.GOT)
 
-            return expr_nodes.FuncCall(cur, args, tok), index
+            return expr_nodes.FuncCall(cur, args), index
 
         elif token_is(index, token_kinds.incr):
             index += 1
@@ -199,6 +198,8 @@ def parse_postfix(index):
             cur = expr_nodes.PostDecr(cur)
         else:
             return cur, index
+
+        cur.r = old_range + p.tokens[index - 1].r
 
 
 @add_range

--- a/shivyc/tree/expr_nodes.py
+++ b/shivyc/tree/expr_nodes.py
@@ -875,12 +875,11 @@ class Deref(_LExprNode):
 class ArraySubsc(_LExprNode):
     """Array subscript."""
 
-    def __init__(self, head, arg, op):
+    def __init__(self, head, arg):
         """Initialize node."""
         super().__init__()
         self.head = head
         self.arg = arg
-        self.op = op
 
     def _lvalue(self, il_code, symbol_table, c):
         """Return lvalue form of this node.
@@ -951,7 +950,7 @@ class ArraySubsc(_LExprNode):
         """
         if not point.ctype.arg.is_complete():
             err = "cannot subscript pointer to incomplete type"
-            raise CompilerError(err, self.op.r)
+            raise CompilerError(err, self.r)
 
         shift = get_size(point.ctype.arg, arith, il_code)
         out = ILValue(point.ctype)
@@ -971,12 +970,11 @@ class ArraySubsc(_LExprNode):
 class _ObjLookup(_LExprNode):
     """Struct/union object lookup (. or ->)"""
 
-    def __init__(self, head, member, tok):
+    def __init__(self, head, member):
         """Initialize node."""
         super().__init__()
         self.head = head
         self.member = member
-        self.tok = tok
 
     def get_offset_info(self, struct_ctype):
         """Given a struct ctype, return the member offset and ctype.
@@ -1044,15 +1042,12 @@ class FuncCall(_RExprNode):
 
     func - Expression of type function pointer
     args - List of expressions for each argument
-    tok - Opening parenthesis of this function call, for error reporting
-
     """
-    def __init__(self, func, args, tok):
+    def __init__(self, func, args):
         """Initialize node."""
         super().__init__()
         self.func = func
         self.args = args
-        self.tok = tok
 
     def make_il(self, il_code, symbol_table, c):
         """Make code for this node."""
@@ -1116,7 +1111,7 @@ class FuncCall(_RExprNode):
             if self.args:
                 raise CompilerError(err, self.args[-1].r)
             else:
-                raise CompilerError(err, self.tok.r)
+                raise CompilerError(err, self.r)
 
         final_args = []
         for arg_given, arg_type in zip(self.args, arg_types):


### PR DESCRIPTION
The following code
```
int main() {
   struct A {int a;} a;
   a.arr[3];
}
```
would previously return an error with no range information. This fixes that bug.
   