### PR TITLE
Implement token range helper function

### DIFF
--- a/shivyc/parser/declaration.py
+++ b/shivyc/parser/declaration.py
@@ -7,7 +7,7 @@ import shivyc.tree.decl_nodes as decl_nodes
 import shivyc.tree.nodes as nodes
 from shivyc.parser.expression import parse_assignment
 from shivyc.parser.utils import (add_range, ParserError, match_token, token_is,
-                                 raise_error, log_error)
+                                 raise_error, log_error, token_range)
 
 
 @add_range
@@ -17,7 +17,7 @@ def parse_func_definition(index):
     specs, index = parse_decl_specifiers(index)
     end = find_decl_end(index)
     decl = parse_declarator(index, end)
-    range = p.tokens[index].r + p.tokens[end - 1].r
+    range = token_range(index, end)
 
     from shivyc.parser.statement import parse_compound_statement
     body, index = parse_compound_statement(end)
@@ -61,7 +61,7 @@ def parse_decls_inits(index, parse_inits=True):
     while True:
         end = find_decl_end(index)
         decls.append(parse_declarator(index, end))
-        ranges.append(p.tokens[index].r + p.tokens[end - 1].r)
+        ranges.append(token_range(index, end))
 
         index = end
         if token_is(index, token_kinds.equals) and parse_inits:
@@ -304,8 +304,8 @@ def parse_parameter_list(index):
         specs, index = parse_decl_specifiers(index)
 
         end = find_decl_end(index)
-        range = p.tokens[index].r + p.tokens[end - 1].r
         decl = parse_declarator(index, end)
+        range = token_range(index, end)
         params.append(decl_nodes.Root(specs, [decl], None, [range]))
 
         index = end

--- a/shivyc/parser/utils.py
+++ b/shivyc/parser/utils.py
@@ -125,6 +125,15 @@ def match_token(index, kind, message_type, message=None):
         raise ParserError(message, index, tokens, message_type)
 
 
+def token_range(start, end):
+    """Generate a range that encompasses tokens[start] to tokens[end-1]"""
+    global tokens
+
+    start_index = min(start, len(tokens) - 1, end - 1)
+    end_index = min(end - 1, len(tokens) - 1)
+    return tokens[start_index].r + tokens[end_index].r
+
+
 def add_range(parse_func):
     """Return a decorated function that tags the produced node with a range.
 
@@ -137,7 +146,7 @@ def add_range(parse_func):
     def parse_with_range(index):
         start_index = index
         node, end_index = parse_func(index)
-        node.r = tokens[start_index].r + tokens[end_index - 1].r
+        node.r = token_range(start_index, end_index)
 
         return node, end_index
 


### PR DESCRIPTION
This avoids an internal compiler error in a situation where `index >= len(tokens)`