### PR TITLE
Prohibit function parameter redefinition

### DIFF
--- a/tests/feature_tests/error_declaration.c
+++ b/tests/feature_tests/error_declaration.c
@@ -22,6 +22,9 @@ int var1;
 // error: redeclared 'var1' with different linkage
 static int var1;
 
+// error: redefinition of 'a'
+void repeat_param(int a, int a);
+
 int main() {
   // error: variable of incomplete type declared
   void a;


### PR DESCRIPTION
Inside function declaration,we cannot define same parameter name.
This commit will prohibit to use same parameter name during function
declaration.