### PR TITLE
Added (possibly non-optimal, but working) support for the CDECL calling convention

### DIFF
--- a/shivyc/asm_cmds.py
+++ b/shivyc/asm_cmds.py
@@ -72,7 +72,7 @@ class Comment:
         self.msg = msg
 
     def __str__(self):  # noqa: D102
-        return "\t// " + self.msg
+        return "\t# " + self.msg
 
 
 class Label:
@@ -95,7 +95,7 @@ class Lea:
         self.source = source
 
     def __str__(self):  # noqa: D102
-        return ("\t" + self.name + " " + self.dest.asm_str(8) + ", "
+        return ("\t" + self.name + " " + self.dest.asm_str(4) + ", "
                 "" + self.source.asm_str(0))
 
 

--- a/shivyc/ctypes.py
+++ b/shivyc/ctypes.py
@@ -190,7 +190,7 @@ class PointerCType(CType):
     def __init__(self, arg, const=False):
         """Initialize type."""
         self.arg = arg
-        super().__init__(8, const)
+        super().__init__(4, const)
 
     def weak_compat(self, other):
         """Return True iff other is a compatible type to self."""
@@ -395,8 +395,8 @@ unsig_int = IntegerCType(4, False)
 int_max = 2147483647
 int_min = -2147483648
 
-longint = IntegerCType(8, True)
-unsig_longint = IntegerCType(8, False)
+longint = IntegerCType(4, True)
+unsig_longint = IntegerCType(4, False)
 long_max = 9223372036854775807
 long_min = -9223372036854775808
 


### PR DESCRIPTION
This code may be a bit messy (because I modified it to emit 32-bit assembly instead of 64-bit), but the main features are the following:

 * CDECL calling convention instead of passing functions' arguments in registers
 * if there are no free registers available in `asm_gen.py`, this uses the stack for local variables instead

Again, the code was modified to emit 32-bit assembly only, so some changes need not be merged into the master branch.