### PR TITLE
Fix a GNU linker error

### DIFF
--- a/shivyc/asm_gen.py
+++ b/shivyc/asm_gen.py
@@ -92,9 +92,13 @@ class ASMCode:
             header += [""]
 
         header += ["\t.section .text"] + self.globals
-        header += [str(line) for line in self.lines]
 
-        return "\n".join(header + ["\t.att_syntax noprefix", ""])
+        code = [str(line) for line in self.lines]
+
+        footer = ["\t.section\t.note.GNU-stack,\"\",@progbits"]
+        footer += ["\t.att_syntax noprefix", ""]
+
+        return "\n".join(header + code + footer)
 
 
 class NodeGraph:


### PR DESCRIPTION
The new GNU linker (ld) complains about missing `.note.GNU-stack section` section when linking object files generated from Shivyc:

```
ld: warning: test.o: missing .note.GNU-stack section implies executable stack
ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```

This diff fixes it by adding the following line to asm:

```
    .section    .note.GNU-stack,"",@progbits
```